### PR TITLE
Fix typo in alpha path in mutagen.yml

### DIFF
--- a/mutagen.yml
+++ b/mutagen.yml
@@ -8,7 +8,7 @@ sync:
         defaultFileMode: 644
         defaultDirectoryMode: 755
     codebase:
-      alpha: ".app"
+      alpha: "./app"
       beta: "docker://mutagen/var/www"
       mode: "two-way-resolved"
       ignore:


### PR DESCRIPTION
Path in `codebase.alpha` should be the app folder, otherwise Mutagen will create a subfolder `.app` with the synced content inside.